### PR TITLE
fix: move mdxld to devDependencies in @mdxdb/types

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,9 +12,9 @@
     "lint": "eslint 'src/**/*.ts' --ignore-pattern '*.d.ts'"
   },
   "dependencies": {
-    "mdxld": "^0.1.0"
   },
   "devDependencies": {
+    "mdxld": "^0.1.0",
     "@eslint/js": "^8.57.0",
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^8.18.1",


### PR DESCRIPTION
This PR moves the mdxld dependency from dependencies to devDependencies in the @mdxdb/types package, following our guidelines for types packages to only contain type definitions with no implementation-specific dependencies.

Changes:
- Moved mdxld from dependencies to devDependencies
- Verified package only contains type definitions
- Confirmed package follows semantic versioning (0.1.0)

Testing:
- ✅ Ran `pnpm install` successfully
- ✅ Built type declarations successfully
- ✅ Verified no implementation code in dist/

Link to Devin run: https://app.devin.ai/sessions/bbb2d25b141243278559393493ff5f6e