### PR TITLE
docs: add CSV/JSONL import documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,22 @@ DEBUG=mdxdb:fs:*,mdxdb:vector:* npm test
 
 ## Development
 
+### CLI Commands
+
+#### Import Data
+Import CSV or JSONL files into MDX documents:
+
+```bash
+mdxdb import <file> --collection <name> [options]
+```
+
+Options:
+- `--format`: Input format (csv|jsonl), default: auto-detected from extension
+- `--id-field`: Field to use as document ID, default: first field or auto-generated UUID
+- `--content-field`: Field to use as main MDX content, default: none (empty content)
+- `--frontmatter-fields`: Fields to include in frontmatter (comma-separated), default: all
+- `--template`: MDX template file to use for content
+
 ```bash
 # Install dependencies
 npm install

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,24 @@
   - [ ] Document interface with JSON-LD support
   - [ ] Collection and Database types
   - [ ] Vector search types and options
+- [ ] CSV/JSONL Import Feature
+  - [ ] CLI Setup
+    - [ ] Create bin directory and CLI entry point
+    - [ ] Add commander.js for CLI argument parsing
+    - [ ] Add import command implementation
+  - [ ] Import Implementation
+    - [ ] Add yaml package for frontmatter handling
+    - [ ] Implement CSV parser using csv-parse
+    - [ ] Implement JSONL parser using readline
+    - [ ] Add frontmatter generation from record fields
+    - [ ] Add MDX content generation from template/field
+  - [ ] Testing
+    - [ ] Add unit tests for parsers
+    - [ ] Add integration tests for import command
+    - [ ] Add example files for testing
+  - [ ] Documentation
+    - [ ] Add usage examples to README
+    - [ ] Add API documentation for programmatic usage
 - [ ] @mdxdb/fetch
   - [ ] HTTP/API provider implementation
   - [ ] RESTful endpoints integration


### PR DESCRIPTION
Add documentation for upcoming CSV/JSONL import feature to README.md and TODO.md.

This PR adds documentation for a new CLI command that will allow importing CSV and JSONL files into MDX documents with YAML frontmatter. Implementation will follow in a separate PR after documentation approval.

Link to Devin run: https://app.devin.ai/sessions/698e771bdeff40c38fae7c0445fef28c