### PR TITLE
docs: add README and TODO for @mdxdb/vscode package

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,0 +1,80 @@
+# @mdxdb/vscode
+
+[![npm version](https://badge.fury.io/js/%40mdxdb%2Fvscode.svg)](https://www.npmjs.com/package/@mdxdb/vscode)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+VSCode extension for MDX file management with integrated AST viewing and preview capabilities.
+
+## Features
+
+- MDX File Management
+  - List and browse MDX files in workspace
+  - View and edit MDX content with syntax highlighting
+  - Integrated file system provider support
+
+- AST Visualization
+  - View MDX Abstract Syntax Tree in JSON5 format
+  - Real-time AST updates as you edit
+  - Collapsible tree view for easy navigation
+
+- MDX Preview
+  - Live preview of rendered MDX content
+  - Support for React components
+  - Hot reload on content changes
+
+- Content Type Support
+  - Structured Data: YAML frontmatter with optional schema validation
+  - Unstructured Content: Markdown editing and preview
+  - Executable Code: JavaScript/TypeScript import/export functionality
+  - UI Components: JSX/React component integration
+
+## Installation
+
+```bash
+npm install @mdxdb/vscode
+```
+
+## Usage
+
+1. Open an MDX file in VSCode
+2. Use the MDX sidebar to browse files
+3. Toggle between edit, AST, and preview modes using the toolbar
+4. Edit content with real-time AST and preview updates
+
+## Configuration
+
+```json
+{
+  'mdxdb.fs.path': '.', // Base path for file system provider
+  'mdxdb.preview.refreshInterval': 1000, // Preview refresh rate in ms
+  'mdxdb.ast.format': 'json5' // AST output format
+}
+```
+
+## API
+
+```typescript
+import { MDXProvider } from '@mdxdb/vscode'
+
+// Initialize provider
+const provider = new MDXProvider({
+  basePath: '.',
+  openaiApiKey: process.env.OPENAI_API_KEY
+})
+
+// List MDX files
+const files = await provider.listFiles()
+
+// Get file content
+const content = await provider.getContent('example.mdx')
+
+// Get AST
+const ast = await provider.getAST('example.mdx')
+```
+
+## Dependencies
+
+- @mdxdb/fs: ^0.1.0
+- @mdxdb/types: ^0.1.0
+- vscode-languageclient: ^8.0.0
+- json5: ^2.2.0

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -30,9 +30,12 @@ VSCode extension for MDX file management with integrated AST viewing and preview
 
 ## Installation
 
-```bash
-npm install @mdxdb/vscode
-```
+1. Open Visual Studio Code
+2. Go to Extensions (Ctrl+Shift+X)
+3. Search for "@mdxdb/vscode"
+4. Click Install
+
+Or install directly from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ai-primitives.mdxdb-vscode).
 
 ## Usage
 
@@ -46,7 +49,7 @@ npm install @mdxdb/vscode
 ```json
 {
   'mdxdb.fs.path': '.', // Base path for file system provider
-  'mdxdb.preview.refreshInterval': 1000, // Preview refresh rate in ms
+  'mdxdb.preview.debounceMs': 300, // Debounce time for preview updates
   'mdxdb.ast.format': 'json5' // AST output format
 }
 ```

--- a/packages/vscode/TODO.md
+++ b/packages/vscode/TODO.md
@@ -1,0 +1,81 @@
+# VSCode Extension Implementation Tasks
+
+## Setup and Configuration
+- [ ] Initialize VSCode extension package
+  - [ ] Set up TypeScript configuration
+  - [ ] Configure extension manifest (package.json)
+  - [ ] Set up development container
+- [ ] Configure build pipeline
+  - [ ] Set up webpack bundling
+  - [ ] Configure extension packaging
+  - [ ] Set up watch mode for development
+
+## Core Features
+- [ ] File System Provider
+  - [ ] Implement FileSystemProvider interface
+  - [ ] Add MDX file detection
+  - [ ] Integrate with @mdxdb/fs package
+  - [ ] Add file watching capabilities
+
+- [ ] MDX Editor
+  - [ ] Set up custom editor provider
+  - [ ] Implement syntax highlighting
+  - [ ] Add auto-completion support
+  - [ ] Implement validation
+
+- [ ] AST Viewer
+  - [ ] Create AST panel view
+  - [ ] Implement JSON5 formatting
+  - [ ] Add collapsible tree view
+  - [ ] Set up real-time AST updates
+
+- [ ] Preview Panel
+  - [ ] Create preview webview
+  - [ ] Set up MDX rendering
+  - [ ] Implement hot reload
+  - [ ] Add component support
+
+## UI Components
+- [ ] Sidebar
+  - [ ] Create activity bar icon
+  - [ ] Implement file tree view
+  - [ ] Add file operations (create, delete, rename)
+
+- [ ] Editor Toolbar
+  - [ ] Add view mode toggles
+  - [ ] Implement refresh button
+  - [ ] Add configuration shortcuts
+
+## Testing
+- [ ] Unit Tests
+  - [ ] File system provider tests
+  - [ ] Editor functionality tests
+  - [ ] AST generation tests
+  - [ ] Preview rendering tests
+
+- [ ] Integration Tests
+  - [ ] End-to-end workflow tests
+  - [ ] Multi-panel interaction tests
+  - [ ] File operation tests
+
+## Documentation
+- [ ] API Documentation
+  - [ ] Document extension API
+  - [ ] Add usage examples
+  - [ ] Create API reference
+
+- [ ] User Guide
+  - [ ] Installation instructions
+  - [ ] Feature documentation
+  - [ ] Configuration guide
+
+## Publishing
+- [ ] Marketplace Preparation
+  - [ ] Create marketplace assets
+  - [ ] Write marketplace description
+  - [ ] Prepare demo screenshots/videos
+
+- [ ] Release Process
+  - [ ] Set up semantic versioning
+  - [ ] Configure automated publishing
+  - [ ] Create changelog generation


### PR DESCRIPTION
# VSCode Extension Documentation

This PR adds initial documentation for the @mdxdb/vscode package, following the documentation-first approach required for new features in ai-primitives repositories.

## Changes
- Added README.md with:
  - Package badges
  - Feature documentation
  - Configuration options
  - API examples
  - Dependencies section
- Added TODO.md with implementation tasks for:
  - Core features (fs provider, editor, AST viewer, preview)
  - UI components
  - Testing requirements
  - Documentation needs
  - Publishing process

## Testing
N/A - Documentation only changes

## Notes
- Focuses on filesystem provider initially
- Supports all four required content types
- Follows MDX-LD extension requirements

Link to Devin run: https://app.devin.ai/sessions/fcc6264be6e04ffe88cff0afe352acef
