### PR TITLE
ci: add VSCode extension workflow

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -1,0 +1,53 @@
+name: VSCode Extension
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/vscode/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/vscode/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/vscode
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run compile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Package Extension
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          npm install -g @vscode/vsce
+          vsce package
+
+      - name: Publish Extension
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          vsce publish -p ${{ secrets.VSCE_PAT }}
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
Add GitHub Actions workflow for VSCode extension publishing

This PR adds a dedicated workflow for building, testing, and publishing the VSCode extension to the marketplace. The workflow includes:
- Automated build and test processes
- Extension packaging with vsce
- Marketplace publishing on main branch
- Path-based triggering for vscode package changes

Link to Devin run: https://app.devin.ai/sessions/fcc6264be6e04ffe88cff0afe352acef